### PR TITLE
SOLID/DRY refactor: centralize helpers, reduce duplication; behavior unchanged

### DIFF
--- a/TEST-IMPROVEMENTS.md
+++ b/TEST-IMPROVEMENTS.md
@@ -4,6 +4,12 @@ This document reviews the current tests, evaluates their value, proposes targete
 
 ## Current State Overview
 
+Latest SOLID/DRY refactor coverage snapshot (branch: SOLID-DRY-refactoring)
+- Overall statements: 95.31%
+- Overall functions: 93.02%
+- Overall lines: 95.31%
+- Overall branches: 88.64%
+
 - Engine and Utilities: strong coverage for movement, legality filtering, check detection, endgame detection, castling, and en passant legality.
 - State management (useChessGame hook): strong for undo/redo, castling rights updates, and en passant execution, including undo/redo and SAN for e.p.
 - Notation (SAN): broad coverage including castling (O-O/O-O-O), disambiguation, captures, promotion (default/explicit and with capture), and check/checkmate suffixes.

--- a/src/hooks/useChessGame.ts
+++ b/src/hooks/useChessGame.ts
@@ -1,6 +1,6 @@
 import { useReducer, useCallback } from 'react'
 import { GameState, GameAction, Square, Move, ChessPiece } from '../types/chess'
-import { createInitialBoard, getPieceAtSquare, isValidSquare, BOARD_SIZE, createInitialCastlingRights, updateCastlingRightsForMove, generateAlgebraicNotation, getCoordinatesFromSquare, computeEnPassantTarget, applyCastlingRookMove, undoCastlingRookMove } from '../utils/chessUtils'
+import { createInitialBoard, getPieceAtSquare, isValidSquare, BOARD_SIZE, createInitialCastlingRights, updateCastlingRightsForMove, generateAlgebraicNotation, getCoordinatesFromSquare, computeEnPassantTarget, applyCastlingRookMove, undoCastlingRookMove, buildMoveRecord } from '../utils/chessUtils'
 import { getValidMoves, isEnPassantMove, computeGameStatus } from '../utils/moveValidation'
 
 // Initial game state
@@ -125,20 +125,18 @@ const gameReducer = (state: GameState, action: GameAction): GameState => {
       const opponentInCheck = finalStatus === 'check' || finalStatus === 'checkmate'
 
       // Create move record capturing previous states for undo with proper algebraic notation
-      const move: Move = {
+const move: Move = buildMoveRecord({
         from,
         to,
         piece,
-        notation: '',
-        timestamp: new Date(),
         captured: enPassantCapturedPiece || capturedPiece || undefined,
         prevHasMoved: movedPiecePrevHasMoved,
         prevCapturedHasMoved: capturedPrevHasMoved,
         prevCastlingRights: state.castlingRights,
+        prevEnPassantTarget: state.enPassantTarget,
         isEnPassant: isEnPassant || undefined,
         enPassantCaptureSquare: enPassantCaptureSquare,
-        prevEnPassantTarget: state.enPassantTarget
-      }
+      })
       const notation = generateAlgebraicNotation(state.board, move, finalStatus)
       move.notation = notation
 
@@ -199,19 +197,17 @@ const gameReducer = (state: GameState, action: GameAction): GameState => {
       const opponentInCheck = computeGameStatus(newBoard, opponent, nextCastlingRights, state.enPassantTarget) === 'check' || computeGameStatus(newBoard, opponent, nextCastlingRights, state.enPassantTarget) === 'checkmate'
       const finalStatus = computeGameStatus(newBoard, opponent, nextCastlingRights, state.enPassantTarget)
 
-      const move: Move = {
+const move: Move = buildMoveRecord({
         from: pp.from,
         to: pp.to,
         piece,
-        notation: '',
-        timestamp: new Date(),
         captured: capturedPiece || undefined,
         prevHasMoved: movedPiecePrevHasMoved,
         prevCapturedHasMoved: capturedPrevHasMoved,
         prevCastlingRights: state.castlingRights,
         prevEnPassantTarget: state.enPassantTarget,
         promotion: promoPieceType
-      }
+      })
       const notation = generateAlgebraicNotation(state.board, move, finalStatus)
       move.notation = notation
 

--- a/src/hooks/useChessGame.ts
+++ b/src/hooks/useChessGame.ts
@@ -1,7 +1,7 @@
 import { useReducer, useCallback } from 'react'
 import { GameState, GameAction, Square, Move, ChessPiece } from '../types/chess'
-import { createInitialBoard, getPieceAtSquare, isValidSquare, BOARD_SIZE, createInitialCastlingRights, updateCastlingRightsForMove, generateAlgebraicNotation, getCoordinatesFromSquare } from '../utils/chessUtils'
-import { getValidMoves, isKingInCheck, isCheckmate, isStalemate, isEnPassantMove } from '../utils/moveValidation'
+import { createInitialBoard, getPieceAtSquare, isValidSquare, BOARD_SIZE, createInitialCastlingRights, updateCastlingRightsForMove, generateAlgebraicNotation, getCoordinatesFromSquare, computeEnPassantTarget, applyCastlingRookMove, undoCastlingRookMove } from '../utils/chessUtils'
+import { getValidMoves, isEnPassantMove, computeGameStatus } from '../utils/moveValidation'
 
 // Initial game state
 export const initialGameState: GameState = {
@@ -99,25 +99,15 @@ const gameReducer = (state: GameState, action: GameAction): GameState => {
       newBoard[toRow][toCol] = { ...piece, hasMoved: true }
       newBoard[fromRow][fromCol] = null
       
-      // Handle castling: move the rook as well
+// Handle castling: move the rook as well
       if (isCastling) {
-        const isKingSide = toCol > fromCol
-        const rookFromCol = isKingSide ? 7 : 0 // h-file or a-file
-        const rookToCol = isKingSide ? 5 : 3   // f-file or d-file
-        
-        const rook = newBoard[fromRow][rookFromCol]
-        if (rook) {
-          newBoard[fromRow][rookToCol] = { ...rook, hasMoved: true }
-          newBoard[fromRow][rookFromCol] = null
-        }
+        applyCastlingRookMove(newBoard, fromRow, fromCol, toCol)
       }
       
-      // Determine new en passant target
+// Determine new en passant target
       let newEnPassantTarget: Square | null = null
-      if (piece.type === 'pawn' && Math.abs(toRow - fromRow) === 2) {
-        // Pawn moved two squares, set en passant target
-        const enPassantRow = (fromRow + toRow) / 2
-        newEnPassantTarget = `${String.fromCharCode('a'.charCodeAt(0) + fromCol)}${BOARD_SIZE - enPassantRow}` as Square
+      if (piece.type === 'pawn') {
+        newEnPassantTarget = computeEnPassantTarget(fromRow, toRow, fromCol)
       }
 
       // Update castling rights based on this move (including captured rook handling)
@@ -131,15 +121,8 @@ const gameReducer = (state: GameState, action: GameAction): GameState => {
       
       const mover = state.currentPlayer
       const opponent = mover === 'white' ? 'black' : 'white'
-      const opponentInCheck = isKingInCheck(newBoard, opponent)
-
-      // Determine game status for the player to move (opponent)
-      const baseStatus = isCheckmate(newBoard, opponent)
-        ? 'checkmate'
-        : isStalemate(newBoard, opponent)
-          ? 'stalemate'
-          : 'active'
-      const finalStatus = baseStatus !== 'active' ? baseStatus : (opponentInCheck ? 'check' : 'active')
+      const finalStatus = computeGameStatus(newBoard, opponent, nextCastlingRights, newEnPassantTarget)
+      const opponentInCheck = finalStatus === 'check' || finalStatus === 'checkmate'
 
       // Create move record capturing previous states for undo with proper algebraic notation
       const move: Move = {
@@ -213,13 +196,8 @@ const gameReducer = (state: GameState, action: GameAction): GameState => {
 
       const mover = state.currentPlayer
       const opponent = mover === 'white' ? 'black' : 'white'
-      const opponentInCheck = isKingInCheck(newBoard, opponent)
-      const baseStatus = isCheckmate(newBoard, opponent)
-        ? 'checkmate'
-        : isStalemate(newBoard, opponent)
-          ? 'stalemate'
-          : 'active'
-      const finalStatus = baseStatus !== 'active' ? baseStatus : (opponentInCheck ? 'check' : 'active')
+      const opponentInCheck = computeGameStatus(newBoard, opponent, nextCastlingRights, state.enPassantTarget) === 'check' || computeGameStatus(newBoard, opponent, nextCastlingRights, state.enPassantTarget) === 'checkmate'
+      const finalStatus = computeGameStatus(newBoard, opponent, nextCastlingRights, state.enPassantTarget)
 
       const move: Move = {
         from: pp.from,
@@ -299,26 +277,12 @@ const gameReducer = (state: GameState, action: GameAction): GameState => {
       
       // Handle castling undo: restore the rook as well
       if (wasCastling) {
-        const isKingSide = toCol > fromCol
-        const rookFromCol = isKingSide ? 7 : 0 // h-file or a-file
-        const rookToCol = isKingSide ? 5 : 3   // f-file or d-file
-        
-        const rook = newBoard[fromRow][rookToCol]
-        if (rook) {
-          // Restore rook to original position (it was also not moved before castling)
-          newBoard[fromRow][rookFromCol] = { ...rook, hasMoved: false }
-          newBoard[fromRow][rookToCol] = null
-        }
+        undoCastlingRookMove(newBoard, fromRow, fromCol, toCol)
       }
       
       const nextCurrent = state.currentPlayer === 'white' ? 'black' : 'white'
-      const nextInCheck = isKingInCheck(newBoard, nextCurrent)
-      const baseStatus = isCheckmate(newBoard, nextCurrent)
-        ? 'checkmate'
-        : isStalemate(newBoard, nextCurrent)
-          ? 'stalemate'
-          : 'active'
-      const finalStatus = baseStatus !== 'active' ? baseStatus : (nextInCheck ? 'check' : 'active')
+      const finalStatus = computeGameStatus(newBoard, nextCurrent, lastMove.prevCastlingRights, lastMove.prevEnPassantTarget || null)
+      const nextInCheck = finalStatus === 'check' || finalStatus === 'checkmate'
 
       return {
         ...state,
@@ -365,35 +329,19 @@ const gameReducer = (state: GameState, action: GameAction): GameState => {
       
       // Handle castling: move the rook as well
       if (isCastling) {
-        const isKingSide = toCol > fromCol
-        const rookFromCol = isKingSide ? 7 : 0 // h-file or a-file
-        const rookToCol = isKingSide ? 5 : 3   // f-file or d-file
-        
-        const rook = newBoard[fromRow][rookFromCol]
-        if (rook) {
-          newBoard[fromRow][rookToCol] = { ...rook, hasMoved: true }
-          newBoard[fromRow][rookFromCol] = null
-        }
+        applyCastlingRookMove(newBoard, fromRow, fromCol, toCol)
       }
       
       // Determine en passant target for the redone move
       let redoEnPassantTarget: Square | null = null
-      if (moveToRedo.piece.type === 'pawn' && Math.abs(toRow - fromRow) === 2) {
-        const enPassantRow = (fromRow + toRow) / 2
-        redoEnPassantTarget = `${String.fromCharCode('a'.charCodeAt(0) + fromCol)}${BOARD_SIZE - enPassantRow}` as Square
+      if (moveToRedo.piece.type === 'pawn') {
+        redoEnPassantTarget = computeEnPassantTarget(fromRow, toRow, fromCol)
       }
       
       const mover = state.currentPlayer
       const opponent = mover === 'white' ? 'black' : 'white'
-      const opponentInCheck = isKingInCheck(newBoard, opponent)
-      
-      // Determine game status for the player to move (opponent)
-      const baseStatus = isCheckmate(newBoard, opponent)
-        ? 'checkmate'
-        : isStalemate(newBoard, opponent)
-          ? 'stalemate'
-          : 'active'
-      const finalStatus = baseStatus !== 'active' ? baseStatus : (opponentInCheck ? 'check' : 'active')
+      const finalStatus = computeGameStatus(newBoard, opponent, state.castlingRights, redoEnPassantTarget)
+      const opponentInCheck = finalStatus === 'check' || finalStatus === 'checkmate'
       
       // Update castling rights based on the redone move
       const nextCastlingRights = updateCastlingRightsForMove(

--- a/src/hooks/useChessGame.ts
+++ b/src/hooks/useChessGame.ts
@@ -124,8 +124,8 @@ const gameReducer = (state: GameState, action: GameAction): GameState => {
       const finalStatus = computeGameStatus(newBoard, opponent, nextCastlingRights, newEnPassantTarget)
       const opponentInCheck = finalStatus === 'check' || finalStatus === 'checkmate'
 
-      // Create move record capturing previous states for undo with proper algebraic notation
-const move: Move = buildMoveRecord({
+// Create move record capturing previous states for undo with proper algebraic notation
+      const move: Move = buildMoveRecord({
         from,
         to,
         piece,
@@ -194,10 +194,11 @@ const move: Move = buildMoveRecord({
 
       const mover = state.currentPlayer
       const opponent = mover === 'white' ? 'black' : 'white'
-      const opponentInCheck = computeGameStatus(newBoard, opponent, nextCastlingRights, state.enPassantTarget) === 'check' || computeGameStatus(newBoard, opponent, nextCastlingRights, state.enPassantTarget) === 'checkmate'
-      const finalStatus = computeGameStatus(newBoard, opponent, nextCastlingRights, state.enPassantTarget)
+      const computedStatus = computeGameStatus(newBoard, opponent, nextCastlingRights, state.enPassantTarget)
+      const opponentInCheck = computedStatus === 'check' || computedStatus === 'checkmate'
+      const finalStatus = computedStatus
 
-const move: Move = buildMoveRecord({
+      const move: Move = buildMoveRecord({
         from: pp.from,
         to: pp.to,
         piece,

--- a/src/utils/chessUtils.ts
+++ b/src/utils/chessUtils.ts
@@ -169,6 +169,52 @@ export const updateCastlingRightsForMove = (
   return newRights
 };
 
+// Apply rook movement that accompanies a castling king move.
+// Mutates the provided board row in-place (expected on a cloned board in reducers).
+export const applyCastlingRookMove = (
+  board: Board,
+  row: number,
+  kingFromCol: number,
+  kingToCol: number
+): void => {
+  const isKingSide = kingToCol > kingFromCol
+  const rookFromCol = isKingSide ? 7 : 0 // h-file or a-file
+  const rookToCol = isKingSide ? 5 : 3   // f-file or d-file
+  const rook = board[row][rookFromCol]
+  if (rook) {
+    board[row][rookToCol] = { ...rook, hasMoved: true }
+    board[row][rookFromCol] = null
+  }
+}
+
+// Undo rook movement from a previous castling move.
+export const undoCastlingRookMove = (
+  board: Board,
+  row: number,
+  kingFromCol: number,
+  kingToCol: number
+): void => {
+  const isKingSide = kingToCol > kingFromCol
+  const rookFromCol = isKingSide ? 7 : 0
+  const rookToCol = isKingSide ? 5 : 3
+  const rook = board[row][rookToCol]
+  if (rook) {
+    board[row][rookFromCol] = { ...rook, hasMoved: false }
+    board[row][rookToCol] = null
+  }
+}
+
+// Compute en passant target square given a two-step pawn move.
+export const computeEnPassantTarget = (
+  fromRow: number,
+  toRow: number,
+  fromCol: number
+): Square | null => {
+  if (Math.abs(toRow - fromRow) !== 2) return null
+  const enPassantRow = (fromRow + toRow) / 2
+  return `${String.fromCharCode('a'.charCodeAt(0) + fromCol)}${BOARD_SIZE - enPassantRow}` as Square
+}
+
 // Notation helpers
 export const getPieceNotationSymbol = (type: PieceType): string => {
   switch (type) {

--- a/src/utils/chessUtils.ts
+++ b/src/utils/chessUtils.ts
@@ -215,6 +215,43 @@ export const computeEnPassantTarget = (
   return `${String.fromCharCode('a'.charCodeAt(0) + fromCol)}${BOARD_SIZE - enPassantRow}` as Square
 }
 
+// Build a Move record consistently (SRP/DRY helper)
+export const buildMoveRecord = (args: {
+  from: Square
+  to: Square
+  piece: ChessPiece
+  captured?: ChessPiece | null
+  prevHasMoved: boolean
+  prevCapturedHasMoved?: boolean
+  prevCastlingRights: CastlingRights
+  prevEnPassantTarget: Square | null
+  isEnPassant?: boolean
+  enPassantCaptureSquare?: Square
+  promotion?: PieceType
+}): Move => {
+  const {
+    from, to, piece, captured,
+    prevHasMoved, prevCapturedHasMoved,
+    prevCastlingRights, prevEnPassantTarget,
+    isEnPassant, enPassantCaptureSquare, promotion
+  } = args
+  return {
+    from,
+    to,
+    piece,
+    notation: '',
+    timestamp: new Date(),
+    captured: captured || undefined,
+    prevHasMoved,
+    prevCapturedHasMoved,
+    prevCastlingRights,
+    prevEnPassantTarget,
+    isEnPassant,
+    enPassantCaptureSquare,
+    promotion,
+  }
+}
+
 // Notation helpers
 export const getPieceNotationSymbol = (type: PieceType): string => {
   switch (type) {


### PR DESCRIPTION
Summary\n- Refactors to improve SOLID/DRY without changing behavior or UI.\n- Centralizes duplicated logic and simplifies the reducer.\n\nChanges\n- utils/moveValidation.ts:\n  - Add slidingMoves() and refactor rook/bishop/queen to use it.\n  - Add computeGameStatus() to centralize active/check/checkmate/stalemate.\n- utils/chessUtils.ts:\n  - Add applyCastlingRookMove()/undoCastlingRookMove().\n  - Add computeEnPassantTarget().\n  - Add buildMoveRecord().\n- hooks/useChessGame.ts:\n  - Delegate status, castling rook motion, en passant target, and Move construction to helpers.\n\nWhy\n- Reduces duplication (DRY), improves Single Responsibility, and nudges toward Dependency Inversion.\n- Keeps rules/notation in utils and keeps the reducer orchestration-focused.\n\nVerification\n- Lint: passed.\n- Tests: 110 tests passed (unit + integration + a11y).\n- Coverage (post-refactor): statements ~95.31%, functions ~93.02%, lines ~95.31%, branches ~88.64% (≥ thresholds).\n\nDocs\n- Added SOLID-DRY-refactoring.md with the plan and checklist.\n- Updated TEST-IMPROVEMENTS.md with coverage snapshot and follow-up ideas.\n\nRisk/impact\n- No API or UI changes; SAN notation preserved; move legality unchanged.\n\nChecklist\n- [x] Lint\n- [x] Unit / integration / a11y tests\n- [x] Coverage thresholds met\n- [x] No breaking changes\n\n